### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ npm install --save-dev qunit-assertions-extra
 
 Then, wherever qunit tests are initialized, add
 ```ts
-import 'qunit-assertions-extra';
+import * as QUnit from 'qunit';
+import { setup } from 'qunit-assertions-extra';
+
+setup(QUnit.assert);
 ```
 
 This will also enable the tsserver to provide intellisense for `assert`.
@@ -33,11 +36,13 @@ Requirements: [ember-auto-import](https://github.com/ef4/ember-auto-import) and 
 Example:
 ```js
 import Application from '../app';
+import * as QUnit from 'qunit';
 import config from '../config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
+import { setup } from 'qunit-assertions-extra';
 
-import 'qunit-assertions-extra';
+setup(QUnit.assert);
 
 setApplication(Application.create(config.APP));
 


### PR DESCRIPTION
👋 

After upgrading from 0.8.5 to 1.x, I ran into errors saying `assert.contains not a function`. Checked the changes for 1.x, and _looks_ like the installation method has changed: 

<img width="1172" alt="Screenshot 2023-05-07 at 16 38 06" src="https://user-images.githubusercontent.com/3893573/236687738-be598674-3b6b-45a7-b42e-01203cb926b1.png">

Using `setup` as mentioned above fixed the errors, I'm not sure if the previous behaviour was supposed to work though. 